### PR TITLE
integrate srt reading for diarization, splitting and speech recognition

### DIFF
--- a/open_dubbing/command_line.py
+++ b/open_dubbing/command_line.py
@@ -197,6 +197,13 @@ class CommandLine:
         )
 
         parser.add_argument(
+            "--input_srt",
+            type=str,
+            default="",
+            help=("A .srt file with speaker annotations that overrides audio segmentation, speaker diarization and speech to text"),
+        )
+        
+        parser.add_argument(
             "--original_subtitles",
             action="store_true",
             default=False,

--- a/open_dubbing/dubbing.py
+++ b/open_dubbing/dubbing.py
@@ -108,6 +108,8 @@ class Dubber:
         clean_intermediate_files: bool = False,
         original_subtitles: bool = False,
         dubbed_subtitles: bool = False,
+        input_srt: str | None = None,
+        
     ) -> None:
         self._input_file = input_file
         self.output_directory = output_directory
@@ -128,6 +130,7 @@ class Dubber:
         self.preprocessing_output = None
         self.original_subtitles = original_subtitles
         self.dubbed_subtitles = dubbed_subtitles
+        self.input_srt = input_srt
 
         if cpu_threads > 0:
             torch.set_num_threads(cpu_threads)
@@ -210,6 +213,7 @@ class Dubber:
             audio_file=audio_file,
             pipeline=self.pyannote_pipeline,
             device=device_pyannote,
+            input_srt=self.input_srt,
         )
         utterance_metadata = audio_processing.run_cut_and_save_audio(
             utterance_metadata=utterance_metadata,
@@ -240,6 +244,7 @@ class Dubber:
             utterance_metadata=self.utterance_metadata,
             source_language=self.source_language,
             no_dubbing_phrases=[],
+            input_srt=self.input_srt,
         )
         speaker_info = self.stt.predict_gender(
             file=media_file,

--- a/open_dubbing/main.py
+++ b/open_dubbing/main.py
@@ -313,6 +313,7 @@ def main():
         clean_intermediate_files=args.clean_intermediate_files,
         original_subtitles=args.original_subtitles,
         dubbed_subtitles=args.dubbed_subtitles,
+        input_srt=args.input_srt,
     )
 
     logger().info(


### PR DESCRIPTION
This PR adds support  for specifying a speaker-annotated .srt file as input to the dubbing process.

The steps of audio chunking, speaker diarization and speech-to-text will not be performed on the audio, rather info from the .srt file will be used.

The proces relies on a .srt file with the following properties:

- only one line of text per subtitle entry
- speaker annotated at the beginning of each line

Example:

5
00:00:13,480 --> 00:00:17,920
[SPEAKER_01]: Deswegen ist er der Kapitän der englischen Nationalmannschaft.

6
00:00:18,039 --> 00:00:21,320
[SPEAKER_01]: Er ist als Spieler sehr gereift und dominiert das Spielgeschehen.

The code uses pysrt for reading the subtitle file. 

Please let me know what needs to be changed to have this merged.